### PR TITLE
chore: update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ide",
     "atom"
   ],
-  "repository": "https://github.com/atom-ide-community/atom-ide-javascript",
+  "repository": "https://github.com/atom-community/atom-ide-javascript",
   "license": "MIT",
   "scripts": {
     "format": "prettier --write .",


### PR DESCRIPTION
Updated the org name from "`atom-ide-community`" to "`atom-community`", in the `repository` field of `package.json`.

This should make the package show in the list of packages published by `atom-community` on atom.io:

- https://atom.io/users/atom-community
- rather than on a separate page for https://atom.io/users/atom-ide-community

This should also fix the loading of the org's avatar/icon at atom.io and in the Atom editor itself.

(By the way, there are [six other packages with the old org URL](https://atom.io/users/atom-ide-community/packages). Let me know if you want PRs for the rest of them.)